### PR TITLE
Update build scripts and documentation for app bundle and IPA generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,6 +362,7 @@ node_modules/
 libraries/tools/kotlin-test-js-runner/lib/
 #local.properties
 buildSrcTmp/
+dist/
 distTmp/
 outTmp/
 /test.output

--- a/README.md
+++ b/README.md
@@ -91,13 +91,23 @@ Create a release build of the app:
   For an App Bundle (recommended for Google Play Store):
 
   ```bash
-  flutter build appbundle
+  ./scripts/build_appbundle.sh
   ```
+
+  Output: `dist/luftdaten-<buildNumber>.aab` (build number from `pubspec.yaml`, e.g. `dist/luftdaten-84.aab`).
 
 - **iOS**:
 
   ```bash
-  flutter build ipa
+  ./scripts/build_ipa.sh
+  ```
+
+  Output: `dist/luftdaten-<buildNumber>.ipa` (build number from `pubspec.yaml`, e.g. `dist/luftdaten-84.ipa`).
+
+  For App Store signing, pass export options:
+
+  ```bash
+  ./scripts/build_ipa.sh --export-options-plist=ios/ExportOptions.plist
   ```
 
   Note that building for iOS only works on macOS.

--- a/scripts/build_appbundle.sh
+++ b/scripts/build_appbundle.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BUILD_NUMBER=$(grep -E '^version:' pubspec.yaml | sed -E 's/.*\+([0-9]+).*/\1/')
+if [[ -z "$BUILD_NUMBER" || "$BUILD_NUMBER" == *version* ]]; then
+  echo "Could not parse build number from pubspec.yaml (expected version: x.y.z+N)" >&2
+  exit 1
+fi
+
+flutter build appbundle "$@"
+
+AAB_SRC=$(find build/app/outputs/bundle -name '*.aab' -print -quit)
+if [[ -z "$AAB_SRC" ]]; then
+  echo "No .aab found under build/app/outputs/bundle" >&2
+  exit 1
+fi
+
+mkdir -p dist
+DEST="dist/luftdaten-${BUILD_NUMBER}.aab"
+cp "$AAB_SRC" "$DEST"
+echo "App bundle copied to $DEST"

--- a/scripts/build_ipa.sh
+++ b/scripts/build_ipa.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+BUILD_NUMBER=$(grep -E '^version:' pubspec.yaml | sed -E 's/.*\+([0-9]+).*/\1/')
+if [[ -z "$BUILD_NUMBER" || "$BUILD_NUMBER" == *version* ]]; then
+  echo "Could not parse build number from pubspec.yaml (expected version: x.y.z+N)" >&2
+  exit 1
+fi
+
+flutter build ipa "$@"
+
+IPA_SRC=$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)
+if [[ -z "$IPA_SRC" ]]; then
+  echo "No .ipa found under build/ios/ipa" >&2
+  exit 1
+fi
+
+mkdir -p dist
+DEST="dist/luftdaten-${BUILD_NUMBER}.ipa"
+cp "$IPA_SRC" "$DEST"
+echo "IPA copied to $DEST"


### PR DESCRIPTION
- Added `build_appbundle.sh` and `build_ipa.sh` scripts to automate the creation of app bundles and IPA files, respectively.
- Updated README.md to reflect the new build commands and output locations for generated files.
- Added `dist/` to .gitignore to prevent distribution files from being tracked.