### PR TITLE
Add chart series preferences and measurement value components

### DIFF
--- a/lib/features/measurements/logic/chart_series_preferences.dart
+++ b/lib/features/measurements/logic/chart_series_preferences.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+import 'package:get_storage/get_storage.dart';
+
+enum ChartSeriesChartId {
+  particulate,
+  temperature,
+  humidity,
+  voc,
+  totalVoc,
+  nox,
+  pressure,
+  co2,
+  o3,
+  aqi,
+  gasResistance,
+}
+
+/// Stable series keys persisted in GetStorage.
+class ChartSeriesKeys {
+  ChartSeriesKeys._();
+
+  static const mean = 'mean';
+  static const pm1 = 'PM1.0';
+  static const pm25 = 'PM2.5';
+  static const pm4 = 'PM4.0';
+  static const pm10 = 'PM10.0';
+}
+
+class ChartSeriesOption {
+  const ChartSeriesOption({required this.key, required this.label});
+
+  final String key;
+  final String label;
+}
+
+class ChartSeriesPreferences extends ChangeNotifier {
+  static const _storageKey = 'chartSeriesVisibility';
+
+  final GetStorage _box = GetStorage('settings');
+  Map<String, Map<String, bool>> _visibility = {};
+
+  void init() {
+    _load();
+  }
+
+  void _load() {
+    final raw = _box.read(_storageKey);
+    if (raw is! Map) {
+      _visibility = {};
+      return;
+    }
+    _visibility = raw.map((chartKey, chartValue) {
+      if (chartValue is! Map) {
+        return MapEntry(chartKey.toString(), <String, bool>{});
+      }
+      return MapEntry(
+        chartKey.toString(),
+        chartValue.map((seriesKey, visible) {
+          return MapEntry(seriesKey.toString(), visible == true);
+        }),
+      );
+    });
+  }
+
+  void _persist() {
+    _box.write(_storageKey, _visibility);
+  }
+
+  String _chartKey(ChartSeriesChartId chart) => chart.name;
+
+  /// Default series visibility when the user has not saved a preference yet.
+  bool defaultVisible(ChartSeriesChartId chart, String seriesKey) {
+    if (chart == ChartSeriesChartId.particulate && seriesKey == ChartSeriesKeys.pm4) {
+      return false;
+    }
+    return true;
+  }
+
+  bool isVisible(
+    ChartSeriesChartId chart,
+    String seriesKey, {
+    bool? defaultValue,
+  }) {
+    final chartMap = _visibility[_chartKey(chart)];
+    final fallback = defaultValue ?? defaultVisible(chart, seriesKey);
+    if (chartMap == null || !chartMap.containsKey(seriesKey)) {
+      return fallback;
+    }
+    return chartMap[seriesKey]!;
+  }
+
+  void setVisible(ChartSeriesChartId chart, String seriesKey, bool visible) {
+    final key = _chartKey(chart);
+    _visibility.putIfAbsent(key, () => {});
+    _visibility[key]![seriesKey] = visible;
+    _persist();
+    notifyListeners();
+  }
+
+  void setAll(ChartSeriesChartId chart, Map<String, bool> values) {
+    _visibility[_chartKey(chart)] = Map<String, bool>.from(values);
+    _persist();
+    notifyListeners();
+  }
+
+  Map<String, bool> visibilityFor(ChartSeriesChartId chart) {
+    final stored = _visibility[_chartKey(chart)];
+    if (stored == null) return {};
+    return Map<String, bool>.from(stored);
+  }
+}

--- a/lib/features/measurements/logic/measurement_values_mock.dart
+++ b/lib/features/measurements/logic/measurement_values_mock.dart
@@ -1,0 +1,49 @@
+import 'package:luftdaten.at/features/measurements/data/measured_data.dart';
+
+/// Rich mock point for comparing last-measurement UI layouts (debug only).
+class MeasurementValuesMock {
+  MeasurementValuesMock._();
+
+  static MeasuredDataPoint samplePoint({DateTime? timestamp}) {
+    return MeasuredDataPoint(
+      timestamp: timestamp ?? DateTime(2026, 6, 8, 14, 32),
+      sensorData: [
+        SensorDataPoint(
+          sensor: LDSensor.sen5x,
+          values: {
+            MeasurableQuantity.pm1: 8.2,
+            MeasurableQuantity.pm25: 12.4,
+            MeasurableQuantity.pm4: 14.1,
+            MeasurableQuantity.pm10: 18.6,
+            MeasurableQuantity.humidity: 55.0,
+            MeasurableQuantity.temperature: 22.3,
+            MeasurableQuantity.voc: 110,
+            MeasurableQuantity.nox: 85,
+          },
+        ),
+        SensorDataPoint(
+          sensor: LDSensor.bme280,
+          values: {
+            MeasurableQuantity.temperature: 21.8,
+            MeasurableQuantity.pressure: 1013.2,
+            MeasurableQuantity.humidity: 53.0,
+          },
+        ),
+        SensorDataPoint(
+          sensor: LDSensor.scd4x,
+          values: {
+            MeasurableQuantity.co2: 850,
+            MeasurableQuantity.temperature: 22.0,
+            MeasurableQuantity.humidity: 54.0,
+          },
+        ),
+        SensorDataPoint(
+          sensor: LDSensor.bme680,
+          values: {
+            MeasurableQuantity.gasResistance: 145,
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/measurements/presentation/pages/chart_page.dart
+++ b/lib/features/measurements/presentation/pages/chart_page.dart
@@ -4,9 +4,12 @@ import 'package:luftdaten.at/features/devices/logic/battery_info_aggregator.dart
 import 'package:luftdaten.at/features/devices/logic/device_manager.dart';
 import 'package:luftdaten.at/core/config/app_settings.dart';
 import 'package:luftdaten.at/core/core.dart';
+import 'package:luftdaten.at/features/measurements/logic/chart_series_preferences.dart';
 import 'package:luftdaten.at/features/measurements/logic/trip_controller.dart';
 import 'package:luftdaten.at/features/measurements/data/measured_data.dart';
 import 'package:luftdaten.at/features/measurements/presentation/pages/chart_page.i18n.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/chart_section.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/measurement_values_panel.dart';
 import 'package:luftdaten.at/features/devices/data/battery_details.dart';
 import 'package:luftdaten.at/core/widgets/change_notifier_builder.dart';
 import 'package:luftdaten.at/core/widgets/start_button.dart';
@@ -41,29 +44,20 @@ class _ChartPageState extends State<ChartPage> {
               return ChangeNotifierBuilder(
                   notifier: getIt<DeviceManager>(),
                   builder: (context, deviceManager) {
-                    if (deviceManager.devices.where((e) => e.portable).isEmpty) {
-                      return Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: Center(
-                          child: Text(
-                            'Auf dieser Seite können Messwerte von tragbaren Messgeräten ausgewertet werden. Füge unter „Geräte“ ein tragbares Messgerät hinzu, oder importiere Messdaten aus JSON oder CSV im Menü rechts oben.'
-                                .i18n,
-                            textAlign: TextAlign.center,
-                          ),
+                    final emptyMessage = deviceManager.devices.where((e) => e.portable).isEmpty
+                        ? 'Auf dieser Seite können Messwerte von tragbaren Messgeräten ausgewertet werden. Füge unter „Geräte“ ein tragbares Messgerät hinzu, oder importiere Messdaten aus JSON oder CSV im Menü rechts oben.'
+                            .i18n
+                        : 'Drücke auf „Messung starten“, um Daten aufzunehmen, oder importiere Messdaten aus früheren Messungen, JSON- oder CSV-Datein im Menü rechts oben.'
+                            .i18n;
+                    return Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Center(
+                        child: Text(
+                          emptyMessage,
+                          textAlign: TextAlign.center,
                         ),
-                      );
-                    } else {
-                      return Padding(
-                        padding: const EdgeInsets.all(12),
-                        child: Center(
-                          child: Text(
-                            'Drücke auf „Messung starten“, um Daten aufzunehmen, oder importiere Messdaten aus früheren Messungen, JSON- oder CSV-Datein im Menü rechts oben.'
-                                .i18n,
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      );
-                    }
+                      ),
+                    );
                   });
             }
             // Reshape data
@@ -85,160 +79,136 @@ class _ChartPageState extends State<ChartPage> {
             }
             List<List<_SensorDataPointWithTimestamp>> reshapedData =
                 reshapedDataMap.values.toList();
-            return SingleChildScrollView(
-              child: Column(
-                children: [
-                  if (data.firstOrNull?.pm1 != null ||
-                      data.firstOrNull?.pm25 != null ||
-                      data.firstOrNull?.pm4 != null ||
-                      data.firstOrNull?.pm10 != null)
-                    SfCartesianChart(
-                      primaryXAxis: DateTimeAxis(
-                        dateFormat: DateFormat('MMM d\nHH:mm'),
-                      ),
-                      title: ChartTitle(text: 'Feinstaubbelastung'.i18n),
-                      primaryYAxis: NumericAxis(
-                        title: AxisTitle(
-                          text: 'Konzentration (μg/m³)'.i18n,
+            return ChangeNotifierBuilder(
+              notifier: getIt<ChartSeriesPreferences>(),
+              builder: (context, chartPrefs) {
+                return SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(12, 12, 12, 8),
+                        child: MeasurementValuesPanel(
+                          point: points.last,
+                          layout: MeasurementValuesLayout.appNativeTiles,
+                          compact: true,
+                          columns: 4,
+                          showTimestamp: true,
                         ),
                       ),
-                      zoomPanBehavior: ZoomPanBehavior(
-                        enablePanning: true,
-                        enablePinching: true,
-                        enableDoubleTapZooming: true,
-                        zoomMode: ZoomMode.x,
-                        enableSelectionZooming: true,
+                      _buildParticulateChart(data, chartPrefs) ?? const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.temperature,
+                            title: 'Temperatur',
+                            yAxisTitle: '°C',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.temperature,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.humidity,
+                            title: 'Luftfeuchtigkeit',
+                            yAxisTitle: '%',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.humidity,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.voc,
+                            title: 'Flüchtige organische Verbindungen (VOC)',
+                            yAxisTitle: 'Index (%)',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.voc,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.totalVoc,
+                            title: 'Flüchtige organische Verbindungen (VOC)',
+                            yAxisTitle: 'ppm', // TODO check unit
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.totalVoc,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.nox,
+                            title: 'Stickoxide (NOx)',
+                            yAxisTitle: 'Index (%)',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.nox,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.pressure,
+                            title: 'Luftdruck',
+                            yAxisTitle: 'hPa',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.pressure,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.co2,
+                            title: 'CO₂',
+                            yAxisTitle: 'ppm',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.co2,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.o3,
+                            title: 'O₃',
+                            yAxisTitle: 'ppb',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.o3,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.aqi,
+                            title: 'Air Quality Index',
+                            yAxisTitle: 'Index',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.aqi,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      _buildChart(
+                            chartId: ChartSeriesChartId.gasResistance,
+                            title: 'Gaswiderstand',
+                            yAxisTitle: 'Index',
+                            data: reshapedData,
+                            dimension: MeasurableQuantity.gasResistance,
+                            preferences: chartPrefs,
+                          ) ??
+                          const SizedBox(),
+                      ChangeNotifierBuilder(
+                        notifier: AppSettings.I,
+                        builder: (context, appSettings) {
+                          if (appSettings.showBatteryGraph) {
+                            return _buildBatteryChart(false) ?? const SizedBox();
+                          }
+                          return const SizedBox();
+                        },
                       ),
-                      legend: const Legend(isVisible: true, position: LegendPosition.bottom),
-                      tooltipBehavior: TooltipBehavior(enable: true),
-                      series: <CartesianSeries<FlattenedDataPoint, DateTime>>[
-                        if (data.first.pm1 != null)
-                          LineSeries<FlattenedDataPoint, DateTime>(
-                            dataSource: data,
-                            xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
-                            yValueMapper: (FlattenedDataPoint item, _) => item.pm1,
-                            name: 'PM1.0',
-                            dataLabelSettings: const DataLabelSettings(isVisible: false),
-                          ),
-                        if (data.first.pm25 != null)
-                          LineSeries<FlattenedDataPoint, DateTime>(
-                            dataSource: data,
-                            xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
-                            yValueMapper: (FlattenedDataPoint item, _) => item.pm25,
-                            name: 'PM2.5',
-                            dataLabelSettings: const DataLabelSettings(isVisible: false),
-                          ),
-                        if (data.first.pm4 != null)
-                          LineSeries<FlattenedDataPoint, DateTime>(
-                            dataSource: data,
-                            xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
-                            yValueMapper: (FlattenedDataPoint item, _) => item.pm4,
-                            name: 'PM4.0',
-                            dataLabelSettings: const DataLabelSettings(isVisible: false),
-                          ),
-                        if (data.first.pm10 != null)
-                          LineSeries<FlattenedDataPoint, DateTime>(
-                            dataSource: data,
-                            xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
-                            yValueMapper: (FlattenedDataPoint item, _) => item.pm10,
-                            name: 'PM10.0',
-                            dataLabelSettings: const DataLabelSettings(isVisible: false),
-                          ),
-                      ],
-                    ),
-                  _buildChart(
-                        title: 'Temperatur',
-                        yAxisTitle: '°C',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.temperature,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Luftfeuchtigkeit',
-                        yAxisTitle: '%',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.humidity,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Flüchtige organische Verbindungen (VOC)',
-                        yAxisTitle: 'Index (%)',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.voc,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Flüchtige organische Verbindungen (VOC)',
-                        yAxisTitle: 'ppm', // TODO check unit
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.totalVoc,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Stickoxide (NOx)',
-                        yAxisTitle: 'Index (%)',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.nox,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Luftdruck',
-                        yAxisTitle: 'hPa',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.pressure,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'CO₂',
-                        yAxisTitle: 'ppm',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.co2,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'O₃',
-                        yAxisTitle: 'ppb',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.o3,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Air Quality Index',
-                        yAxisTitle: 'Index',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.aqi,
-                      ) ??
-                      const SizedBox(),
-                  _buildChart(
-                        title: 'Gaswiderstand',
-                        yAxisTitle: 'Index',
-                        data: reshapedData,
-                        dimension: MeasurableQuantity.gasResistance,
-                      ) ??
-                      const SizedBox(),
-                  // Battery percentage chart
-                  ChangeNotifierBuilder(
-                    notifier: AppSettings.I,
-                    builder: (context, appSettings) {
-                      if (appSettings.showBatteryGraph) {
-                        return _buildBatteryChart(false) ?? const SizedBox();
-                      }
-                      return const SizedBox();
-                    },
+                      ChangeNotifierBuilder(
+                        notifier: AppSettings.I,
+                        builder: (context, appSettings) {
+                          if (appSettings.showBatteryGraph) {
+                            return _buildBatteryChart(true) ?? const SizedBox();
+                          }
+                          return const SizedBox();
+                        },
+                      ),
+                      const SizedBox(height: 90),
+                    ],
                   ),
-                  // Battery voltage chart
-                  ChangeNotifierBuilder(
-                    notifier: AppSettings.I,
-                    builder: (context, appSettings) {
-                      if (appSettings.showBatteryGraph) {
-                        return _buildBatteryChart(true) ?? const SizedBox();
-                      }
-                      return const SizedBox();
-                    },
-                  ),
-                  const SizedBox(height: 90),
-                ],
-              ),
+                );
+              },
             );
           }),
           if (!widget.isFullscreen)
@@ -281,19 +251,119 @@ class _ChartPageState extends State<ChartPage> {
     );
   }
 
+  Widget? _buildParticulateChart(
+    List<FlattenedDataPoint> data,
+    ChartSeriesPreferences preferences,
+  ) {
+    if (data.isEmpty) return null;
+
+    final options = <ChartSeriesOption>[
+      if (data.first.pm1 != null)
+        const ChartSeriesOption(key: ChartSeriesKeys.pm1, label: 'PM1.0'),
+      if (data.first.pm25 != null)
+        const ChartSeriesOption(key: ChartSeriesKeys.pm25, label: 'PM2.5'),
+      if (data.first.pm4 != null)
+        const ChartSeriesOption(key: ChartSeriesKeys.pm4, label: 'PM4.0'),
+      if (data.first.pm10 != null)
+        const ChartSeriesOption(key: ChartSeriesKeys.pm10, label: 'PM10.0'),
+    ];
+    if (options.isEmpty) return null;
+
+    final series = <CartesianSeries<FlattenedDataPoint, DateTime>>[];
+    if (data.first.pm1 != null &&
+        preferences.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm1)) {
+      series.add(LineSeries<FlattenedDataPoint, DateTime>(
+        dataSource: data,
+        xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
+        yValueMapper: (FlattenedDataPoint item, _) => item.pm1,
+        name: 'PM1.0',
+        dataLabelSettings: const DataLabelSettings(isVisible: false),
+      ));
+    }
+    if (data.first.pm25 != null &&
+        preferences.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm25)) {
+      series.add(LineSeries<FlattenedDataPoint, DateTime>(
+        dataSource: data,
+        xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
+        yValueMapper: (FlattenedDataPoint item, _) => item.pm25,
+        name: 'PM2.5',
+        dataLabelSettings: const DataLabelSettings(isVisible: false),
+      ));
+    }
+    if (data.first.pm4 != null &&
+        preferences.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm4)) {
+      series.add(LineSeries<FlattenedDataPoint, DateTime>(
+        dataSource: data,
+        xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
+        yValueMapper: (FlattenedDataPoint item, _) => item.pm4,
+        name: 'PM4.0',
+        dataLabelSettings: const DataLabelSettings(isVisible: false),
+      ));
+    }
+    if (data.first.pm10 != null &&
+        preferences.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm10)) {
+      series.add(LineSeries<FlattenedDataPoint, DateTime>(
+        dataSource: data,
+        xValueMapper: (FlattenedDataPoint item, _) => item.timestamp,
+        yValueMapper: (FlattenedDataPoint item, _) => item.pm10,
+        name: 'PM10.0',
+        dataLabelSettings: const DataLabelSettings(isVisible: false),
+      ));
+    }
+    if (series.isEmpty) return null;
+
+    return ChartSection(
+      title: _chartHeadline('Feinstaubbelastung', 'μg/m³'),
+      chartId: ChartSeriesChartId.particulate,
+      seriesOptions: options,
+      chart: SfCartesianChart(
+        primaryXAxis: DateTimeAxis(
+          dateFormat: DateFormat('MMM d\nHH:mm'),
+        ),
+        primaryYAxis: _measurementYAxis(),
+        zoomPanBehavior: ZoomPanBehavior(
+          enablePanning: true,
+          enablePinching: true,
+          enableDoubleTapZooming: true,
+          zoomMode: ZoomMode.x,
+          enableSelectionZooming: true,
+        ),
+        legend: Legend(
+          isVisible: series.length > 1,
+          position: LegendPosition.bottom,
+        ),
+        tooltipBehavior: TooltipBehavior(enable: true),
+        series: series,
+      ),
+    );
+  }
+
   Widget? _buildChart({
+    required ChartSeriesChartId chartId,
     required String title,
     required String yAxisTitle,
     required List<List<_SensorDataPointWithTimestamp>> data,
     required MeasurableQuantity dimension,
+    required ChartSeriesPreferences preferences,
   }) {
-    // Data must be sorted in one list per reporting sensor
-    // Safe to call if dimension is not in data
     List<List<_SensorDataPointWithTimestamp>> qualifyingData =
         data.where((e) => e.firstOrNull?.data.values.containsKey(dimension) ?? false).toList();
     if (qualifyingData.isEmpty) return null;
+
+    final options = <ChartSeriesOption>[
+      for (final sensorData in qualifyingData)
+        ChartSeriesOption(
+          key: sensorData.first.data.sensor.name,
+          label: sensorData.first.data.sensor.shortName,
+        ),
+      if (qualifyingData.length > 1)
+        ChartSeriesOption(key: ChartSeriesKeys.mean, label: 'Mittelwert'.i18n),
+    ];
+
     List<LineSeries> series = [];
     for (List<_SensorDataPointWithTimestamp> sensorData in qualifyingData) {
+      final sensorKey = sensorData.first.data.sensor.name;
+      if (!preferences.isVisible(chartId, sensorKey)) continue;
       series.add(LineSeries<_SensorDataPointWithTimestamp, DateTime>(
         dataSource: sensorData,
         xValueMapper: (_SensorDataPointWithTimestamp item, _) => item.timestamp,
@@ -302,8 +372,8 @@ class _ChartPageState extends State<ChartPage> {
         dataLabelSettings: const DataLabelSettings(isVisible: false),
       ));
     }
-    if (qualifyingData.length > 1) {
-      // Add mean
+    if (qualifyingData.length > 1 &&
+        preferences.isVisible(chartId, ChartSeriesKeys.mean)) {
       List<_SensorDataPointWithTimestamp> meanData = [];
       for (int i = 0; i < qualifyingData.first.length; i++) {
         double sum = 0;
@@ -319,45 +389,58 @@ class _ChartPageState extends State<ChartPage> {
         dataSource: meanData,
         xValueMapper: (_SensorDataPointWithTimestamp item, _) => item.timestamp,
         yValueMapper: (_SensorDataPointWithTimestamp item, _) => item.data.values[dimension]!,
-        name: 'Mittelwert',
+        name: 'Mittelwert'.i18n,
         width: 4,
         dataLabelSettings: const DataLabelSettings(isVisible: false),
       ));
     }
-    return SfCartesianChart(
-      primaryXAxis: DateTimeAxis(
-        dateFormat: DateFormat('MMM d\nHH:mm'),
-      ),
-      title: ChartTitle(text: title.i18n),
-      primaryYAxis: NumericAxis(
-        title: AxisTitle(
-          text: yAxisTitle.i18n,
+    if (series.isEmpty) return null;
+
+    return ChartSection(
+      title: _chartHeadline(title, yAxisTitle),
+      chartId: chartId,
+      seriesOptions: options,
+      chart: SfCartesianChart(
+        primaryXAxis: DateTimeAxis(
+          dateFormat: DateFormat('MMM d\nHH:mm'),
         ),
+        primaryYAxis: _measurementYAxis(),
+        zoomPanBehavior: ZoomPanBehavior(
+          enablePanning: true,
+          enablePinching: true,
+          enableDoubleTapZooming: true,
+          zoomMode: ZoomMode.x,
+          enableSelectionZooming: true,
+        ),
+        legend: Legend(
+          isVisible: series.length > 1,
+          position: LegendPosition.bottom,
+        ),
+        tooltipBehavior: TooltipBehavior(enable: true),
+        series: series,
       ),
-      zoomPanBehavior: ZoomPanBehavior(
-        enablePanning: true,
-        enablePinching: true,
-        enableDoubleTapZooming: true,
-        zoomMode: ZoomMode.x,
-        enableSelectionZooming: true,
-      ),
-      legend: const Legend(isVisible: true, position: LegendPosition.bottom),
-      tooltipBehavior: TooltipBehavior(enable: true),
-      series: series,
     );
   }
 
+  String _chartHeadline(String title, String unit) =>
+      '%s in %s'.i18n.fill([title.i18n, unit.i18n]);
+
+  NumericAxis _measurementYAxis() => const NumericAxis();
+
   Widget? _buildBatteryChart(bool voltage) {
-    return SfCartesianChart(
+    final headline = voltage
+        ? _chartHeadline('Batteriestatus', '%')
+        : _chartHeadline('Batteriespannung', 'V');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        CenteredChartHeadline(title: headline),
+        SfCartesianChart(
       primaryXAxis: DateTimeAxis(
         dateFormat: DateFormat('MMM d\nHH:mm'),
       ),
-      title: ChartTitle(text: 'Batteriestatus'.i18n),
-      primaryYAxis: NumericAxis(
-        title: AxisTitle(
-          text: voltage ? 'Ladestatus (%)'.i18n : 'Batteriespannung (V)'.i18n,
-        ),
-      ),
+      primaryYAxis: _measurementYAxis(),
       zoomPanBehavior: ZoomPanBehavior(
         enablePanning: true,
         enablePinching: true,
@@ -365,7 +448,7 @@ class _ChartPageState extends State<ChartPage> {
         zoomMode: ZoomMode.x,
         enableSelectionZooming: true,
       ),
-      legend: const Legend(isVisible: true, position: LegendPosition.bottom),
+      legend: const Legend(isVisible: false, position: LegendPosition.bottom),
       tooltipBehavior: TooltipBehavior(enable: true),
       series: [
         LineSeries<BatteryDetails, DateTime>(
@@ -374,6 +457,8 @@ class _ChartPageState extends State<ChartPage> {
           yValueMapper: (BatteryDetails item, _) => voltage ? item.percentage : item.voltage,
           name: 'Batteriestatus'.i18n,
           dataLabelSettings: const DataLabelSettings(isVisible: false),
+        ),
+      ],
         ),
       ],
     );

--- a/lib/features/measurements/presentation/pages/chart_page.i18n.dart
+++ b/lib/features/measurements/presentation/pages/chart_page.i18n.dart
@@ -64,9 +64,59 @@ extension Localization on String {
         "en": "Charge status (%)",
       } +
       {
+        "de": "Mittelwert",
+        "en": "Mean",
+      } +
+      {
+        "de": "Letzte Messwerte",
+        "en": "Latest measurements",
+      } +
+      {
         "de": "Batteriespannung (V)",
         "en": "Battery voltage (V)",
+      } +
+      {
+        "de": "%s in %s",
+        "en": "%s in %s",
+      } +
+      {
+        "de": "Batteriespannung",
+        "en": "Battery voltage",
+      } +
+      {
+        "de": "Luftdruck",
+        "en": "Air pressure",
+      } +
+      {
+        "de": "Air Quality Index",
+        "en": "Air Quality Index",
+      } +
+      {
+        "de": "Gaswiderstand",
+        "en": "Gas resistance",
+      } +
+      {
+        "de": "μg/m³",
+        "en": "μg/m³",
+      } +
+      {
+        "de": "hPa",
+        "en": "hPa",
+      } +
+      {
+        "de": "ppm",
+        "en": "ppm",
+      } +
+      {
+        "de": "ppb",
+        "en": "ppb",
+      } +
+      {
+        "de": "Index",
+        "en": "Index",
       };
 
   String get i18n => localize(this, _t);
+
+  String fill(List<Object> params) => localizeFill(this, params, _t);
 }

--- a/lib/features/measurements/presentation/widgets/chart_section.dart
+++ b/lib/features/measurements/presentation/widgets/chart_section.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:luftdaten.at/features/measurements/logic/chart_series_preferences.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/chart_series_config_dialog.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/chart_series_config_dialog.i18n.dart';
+
+class CenteredChartHeadline extends StatelessWidget {
+  const CenteredChartHeadline({
+    super.key,
+    required this.title,
+    this.trailing,
+  });
+
+  final String title;
+  final Widget? trailing;
+
+  static const _sideSlotWidth = 48.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+      child: Row(
+        children: [
+          const SizedBox(width: _sideSlotWidth),
+          Expanded(
+            child: Text(
+              title,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ),
+          SizedBox(
+            width: _sideSlotWidth,
+            child: trailing,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ChartSection extends StatelessWidget {
+  const ChartSection({
+    super.key,
+    required this.title,
+    required this.chartId,
+    required this.seriesOptions,
+    required this.chart,
+  });
+
+  final String title;
+  final ChartSeriesChartId chartId;
+  final List<ChartSeriesOption> seriesOptions;
+  final Widget chart;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        CenteredChartHeadline(
+          title: title,
+          trailing: seriesOptions.length >= 2
+              ? IconButton(
+                  icon: const Icon(Icons.tune),
+                  tooltip: 'Diagramm konfigurieren'.i18n,
+                  onPressed: () => showChartSeriesConfigDialog(
+                    context,
+                    chartTitle: title,
+                    chartId: chartId,
+                    options: seriesOptions,
+                  ),
+                )
+              : null,
+        ),
+        chart,
+      ],
+    );
+  }
+}

--- a/lib/features/measurements/presentation/widgets/chart_series_config_dialog.dart
+++ b/lib/features/measurements/presentation/widgets/chart_series_config_dialog.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:luftdaten.at/core/core.dart';
+import 'package:luftdaten.at/core/widgets/ui.dart';
+import 'package:luftdaten.at/features/measurements/logic/chart_series_preferences.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/chart_series_config_dialog.i18n.dart';
+
+Future<void> showChartSeriesConfigDialog(
+  BuildContext context, {
+  required String chartTitle,
+  required ChartSeriesChartId chartId,
+  required List<ChartSeriesOption> options,
+}) async {
+  final prefs = getIt<ChartSeriesPreferences>();
+  final local = {
+    for (final option in options) option.key: prefs.isVisible(chartId, option.key),
+  };
+
+  await showLDDialog(
+    context,
+    title: 'Diagramm konfigurieren'.i18n,
+    icon: Icons.tune,
+    content: StatefulBuilder(
+      builder: (context, setState) {
+        return SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                chartTitle,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              Text('Anzuzeigende Daten'.i18n),
+              const SizedBox(height: 4),
+              for (final option in options)
+                CheckboxListTile(
+                  contentPadding: EdgeInsets.zero,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  value: local[option.key] ?? true,
+                  title: Text(option.label),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    final visibleCount = local.values.where((e) => e).length;
+                    if (!value && visibleCount <= 1) {
+                      snackMessage(
+                        context,
+                        'Mindestens eine Reihe muss sichtbar bleiben.'.i18n,
+                      );
+                      return;
+                    }
+                    setState(() => local[option.key] = value);
+                  },
+                ),
+            ],
+          ),
+        );
+      },
+    ),
+    actions: [
+      LDDialogAction.cancel(),
+      LDDialogAction.save(
+        onTap: () => prefs.setAll(chartId, local),
+      ),
+    ],
+  );
+}

--- a/lib/features/measurements/presentation/widgets/chart_series_config_dialog.i18n.dart
+++ b/lib/features/measurements/presentation/widgets/chart_series_config_dialog.i18n.dart
@@ -1,0 +1,25 @@
+import 'package:i18n_extension/i18n_extension.dart';
+
+extension Localization on String {
+  static final _t = Translations.byText('de') +
+      {
+        'de': 'Diagramm konfigurieren',
+        'en': 'Configure chart',
+      } +
+      {
+        'de': 'Anzuzeigende Daten',
+        'en': 'Data to display',
+      } +
+      {
+        'de': 'Mittelwert',
+        'en': 'Mean',
+      } +
+      {
+        'de': 'Mindestens eine Reihe muss sichtbar bleiben.',
+        'en': 'At least one series must remain visible.',
+      };
+
+  String get i18n => localize(this, _t);
+
+  String fill(List<Object> params) => localizeFill(this, params, _t);
+}

--- a/lib/features/measurements/presentation/widgets/measurement_metric_entry.dart
+++ b/lib/features/measurements/presentation/widgets/measurement_metric_entry.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:luftdaten.at/core/domain/dimensions.dart' as dim;
+import 'package:luftdaten.at/core/utils/gradient_color.dart';
+import 'package:luftdaten.at/features/measurements/data/measured_data.dart';
+
+enum MeasurementValueCategory {
+  particulate,
+  climate,
+  gases,
+}
+
+class MeasurementMetricEntry {
+  const MeasurementMetricEntry({
+    required this.quantity,
+    required this.value,
+    required this.sensor,
+    required this.statusColor,
+    required this.formattedValue,
+    required this.sensorSymbol,
+  });
+
+  final MeasurableQuantity quantity;
+  final double value;
+  final LDSensor sensor;
+  final Color statusColor;
+  final String formattedValue;
+  final String sensorSymbol;
+
+  String get label => quantity.name;
+
+  String get unit => quantity.csvUnit;
+
+  MeasurementValueCategory get category => switch (quantity) {
+        MeasurableQuantity.pm01 ||
+        MeasurableQuantity.pm1 ||
+        MeasurableQuantity.pm25 ||
+        MeasurableQuantity.pm4 ||
+        MeasurableQuantity.pm10 =>
+          MeasurementValueCategory.particulate,
+        MeasurableQuantity.temperature ||
+        MeasurableQuantity.humidity ||
+        MeasurableQuantity.pressure =>
+          MeasurementValueCategory.climate,
+        _ => MeasurementValueCategory.gases,
+      };
+
+  String get sensorHint =>
+      sensorSymbol.isEmpty ? sensor.shortName : '$sensorSymbol ${sensor.shortName}';
+}
+
+class MeasurementMetricParser {
+  MeasurementMetricParser._();
+
+  static List<MeasurementMetricEntry> fromDataPoint(MeasuredDataPoint point) {
+    final values = <MeasurableQuantity, Map<LDSensor, double>>{};
+    for (final sensorData in point.sensorData) {
+      for (final quantity in sensorData.values.keys) {
+        values.putIfAbsent(quantity, () => {});
+        values[quantity]![sensorData.sensor] = sensorData.values[quantity]!;
+      }
+    }
+
+    final sensorsWithOverlap = <LDSensor>{};
+    for (final dimensionValues in values.values) {
+      if (dimensionValues.length > 1) {
+        sensorsWithOverlap.addAll(dimensionValues.keys);
+      }
+    }
+    final sortedOverlap = sensorsWithOverlap.toList()..sort((a, b) => a.index.compareTo(b.index));
+    final sensorSymbols = {
+      for (var i = 0; i < sortedOverlap.length; i++) sortedOverlap[i]: '*' * (i + 1),
+    };
+
+    final entries = <MeasurementMetricEntry>[];
+    for (final quantity in _displayOrder) {
+      final dimensionValues = values[quantity];
+      if (dimensionValues == null) continue;
+      for (final sensor in dimensionValues.keys.toList()
+        ..sort((a, b) => a.index.compareTo(b.index))) {
+        final value = dimensionValues[sensor]!;
+        entries.add(
+          MeasurementMetricEntry(
+            quantity: quantity,
+            value: value,
+            sensor: sensor,
+            statusColor: statusColor(quantity, value),
+            formattedValue: _formatValue(quantity, value),
+            sensorSymbol: sensorSymbols[sensor] ?? '',
+          ),
+        );
+      }
+    }
+    return entries;
+  }
+
+  static const _displayOrder = [
+    MeasurableQuantity.pm1,
+    MeasurableQuantity.pm25,
+    MeasurableQuantity.pm4,
+    MeasurableQuantity.pm10,
+    MeasurableQuantity.nox,
+    MeasurableQuantity.voc,
+    MeasurableQuantity.totalVoc,
+    MeasurableQuantity.temperature,
+    MeasurableQuantity.humidity,
+    MeasurableQuantity.pressure,
+    MeasurableQuantity.co2,
+    MeasurableQuantity.o3,
+    MeasurableQuantity.aqi,
+    MeasurableQuantity.gasResistance,
+  ];
+
+  static String _formatValue(MeasurableQuantity quantity, double value) {
+    if (quantity == MeasurableQuantity.aqi) {
+      return value.round().toString();
+    }
+    return value.toStringAsFixed(1);
+  }
+
+  static Color statusColor(MeasurableQuantity dimension, double value) {
+    switch (dimension) {
+      case MeasurableQuantity.pm1:
+        return dim.Dimension.getColor(dim.Dimension.PM1_0, value) as Color;
+      case MeasurableQuantity.pm25:
+        return dim.Dimension.getColor(dim.Dimension.PM2_5, value) as Color;
+      case MeasurableQuantity.pm4:
+        return dim.Dimension.getColor(dim.Dimension.PM4_0, value) as Color;
+      case MeasurableQuantity.pm10:
+        return dim.Dimension.getColor(dim.Dimension.PM10_0, value) as Color;
+      case MeasurableQuantity.nox:
+        return GradientColor.nox().getColor(value);
+      case MeasurableQuantity.voc:
+        return GradientColor.voc().getColor(value);
+      case MeasurableQuantity.totalVoc:
+        return GradientColor.totalVoc().getColor(value);
+      case MeasurableQuantity.temperature:
+        return GradientColor.temperature().getColor(value);
+      case MeasurableQuantity.humidity:
+        return GradientColor.humidity().getColor(value);
+      case MeasurableQuantity.pressure:
+        return GradientColor.pressure().getColor(value);
+      case MeasurableQuantity.co2:
+        return GradientColor.co2().getColor(value);
+      case MeasurableQuantity.o3:
+        return GradientColor.o3().getColor(value);
+      case MeasurableQuantity.aqi:
+        return GradientColor.aqi().getColor(value);
+      case MeasurableQuantity.gasResistance:
+        return GradientColor.gasResistance().getColor(value);
+      default:
+        return Colors.grey.shade700;
+    }
+  }
+}

--- a/lib/features/measurements/presentation/widgets/measurement_values_comparison.dart
+++ b/lib/features/measurements/presentation/widgets/measurement_values_comparison.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:luftdaten.at/features/measurements/data/measured_data.dart';
+import 'package:luftdaten.at/features/measurements/logic/measurement_values_mock.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/measurement_values_panel.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/measurement_values_panel.i18n.dart';
+
+/// Debug-only side-by-side preview of all last-measurement box layouts.
+class MeasurementValuesComparison extends StatelessWidget {
+  const MeasurementValuesComparison({
+    super.key,
+    this.point,
+  });
+
+  final MeasuredDataPoint? point;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!kDebugMode) return const SizedBox.shrink();
+
+    final sample = point ?? MeasurementValuesMock.samplePoint();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 4),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Layout-Vergleich (Debug)'.i18n,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Alle Varianten mit denselben Mock-Messwerten zum Vergleich.'.i18n,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+              const SizedBox(height: 16),
+              for (final layout in MeasurementValuesLayout.values) ...[
+                Text(
+                  layout.label,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(height: 8),
+                MeasurementValuesPanel(
+                  point: sample,
+                  layout: layout,
+                  showTimestamp: layout == MeasurementValuesLayout.values.first,
+                ),
+                if (layout != MeasurementValuesLayout.values.last) ...[
+                  const SizedBox(height: 16),
+                  Divider(color: Theme.of(context).dividerColor),
+                  const SizedBox(height: 16),
+                ],
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/measurements/presentation/widgets/measurement_values_panel.dart
+++ b/lib/features/measurements/presentation/widgets/measurement_values_panel.dart
@@ -1,0 +1,374 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:luftdaten.at/features/measurements/data/measured_data.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/measurement_metric_entry.dart';
+import 'package:luftdaten.at/features/measurements/presentation/widgets/measurement_values_panel.i18n.dart';
+
+enum MeasurementValuesLayout {
+  md3StatCards,
+  appNativeTiles,
+  colorFilledKpi,
+  groupedSections,
+}
+
+extension MeasurementValuesLayoutLabels on MeasurementValuesLayout {
+  String get label => switch (this) {
+        MeasurementValuesLayout.md3StatCards => 'MD3 Stat Cards'.i18n,
+        MeasurementValuesLayout.appNativeTiles => 'App-native Tiles'.i18n,
+        MeasurementValuesLayout.colorFilledKpi => 'Color-filled KPI'.i18n,
+        MeasurementValuesLayout.groupedSections => 'Gruppierte Sektionen'.i18n,
+      };
+}
+
+class MeasurementValuesPanel extends StatelessWidget {
+  const MeasurementValuesPanel({
+    super.key,
+    required this.point,
+    required this.layout,
+    this.showTimestamp = true,
+    this.compact = false,
+    this.columns,
+  });
+
+  final MeasuredDataPoint point;
+  final MeasurementValuesLayout layout;
+  final bool showTimestamp;
+  final bool compact;
+  final int? columns;
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = MeasurementMetricParser.fromDataPoint(point);
+    if (entries.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (showTimestamp)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Text(
+              '${'Gemessen:'.i18n} ${DateFormat('dd.MM.yyyy, HH:mm.').format(point.timestamp)}',
+              style: const TextStyle(fontWeight: FontWeight.w600),
+              textAlign: TextAlign.center,
+            ),
+          ),
+        switch (layout) {
+          MeasurementValuesLayout.md3StatCards => _MetricGrid(
+              entries: entries,
+              tileBuilder: (entry) => _Md3StatCard(entry, compact: compact),
+              columns: columns,
+              compact: compact,
+            ),
+          MeasurementValuesLayout.appNativeTiles => _MetricGrid(
+              entries: entries,
+              tileBuilder: (entry) => _AppNativeTile(entry, compact: compact),
+              columns: columns,
+              compact: compact,
+            ),
+          MeasurementValuesLayout.colorFilledKpi => _MetricGrid(
+              entries: entries,
+              tileBuilder: (entry) => _ColorFilledKpi(entry, compact: compact),
+              columns: columns,
+              compact: compact,
+            ),
+          MeasurementValuesLayout.groupedSections => _GroupedSections(
+              entries: entries,
+              compact: compact,
+              columns: columns,
+            ),
+        },
+      ],
+    );
+  }
+}
+
+class _MetricGrid extends StatelessWidget {
+  const _MetricGrid({
+    required this.entries,
+    required this.tileBuilder,
+    this.columns,
+    this.compact = false,
+  });
+
+  final List<MeasurementMetricEntry> entries;
+  final Widget Function(MeasurementMetricEntry entry) tileBuilder;
+  final int? columns;
+  final bool compact;
+
+  static int _columnCount(double width, int? columns, bool compact) {
+    if (columns != null) return columns;
+    if (compact) return width >= 280 ? 4 : 2;
+    return width >= 520 ? 3 : 2;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final spacing = compact ? 6.0 : 8.0;
+        final cols = _columnCount(constraints.maxWidth, columns, compact);
+        final tileWidth = (constraints.maxWidth - spacing * (cols - 1)) / cols;
+        return Wrap(
+          spacing: spacing,
+          runSpacing: spacing,
+          children: [
+            for (final entry in entries)
+              SizedBox(
+                width: tileWidth,
+                child: tileBuilder(entry),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _Md3StatCard extends StatelessWidget {
+  const _Md3StatCard(this.entry, {this.compact = false});
+
+  final MeasurementMetricEntry entry;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: scheme.surface,
+        borderRadius: BorderRadius.circular(compact ? 8 : 12),
+        border: Border(
+          left: BorderSide(color: entry.statusColor, width: compact ? 3 : 4),
+          top: BorderSide(color: scheme.outlineVariant),
+          right: BorderSide(color: scheme.outlineVariant),
+          bottom: BorderSide(color: scheme.outlineVariant),
+        ),
+      ),
+      padding: EdgeInsets.fromLTRB(compact ? 6 : 10, compact ? 6 : 10, compact ? 6 : 10, compact ? 8 : 12),
+      child: _MetricTileContent(
+        entry: entry,
+        valueColor: entry.statusColor,
+        compact: compact,
+        labelStyle: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: scheme.onSurfaceVariant,
+              fontSize: compact ? 10 : null,
+            ),
+      ),
+    );
+  }
+}
+
+class _AppNativeTile extends StatelessWidget {
+  const _AppNativeTile(this.entry, {this.compact = false});
+
+  final MeasurementMetricEntry entry;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: scheme.primaryContainer.withValues(alpha: 0.35),
+        borderRadius: BorderRadius.circular(compact ? 8 : 12),
+      ),
+      padding: EdgeInsets.all(compact ? 6 : 10),
+      child: _MetricTileContent(
+        entry: entry,
+        valueColor: entry.statusColor,
+        compact: compact,
+        labelStyle: Theme.of(context).textTheme.labelSmall?.copyWith(
+              fontSize: compact ? 10 : null,
+            ),
+      ),
+    );
+  }
+}
+
+class _ColorFilledKpi extends StatelessWidget {
+  const _ColorFilledKpi(this.entry, {this.compact = false});
+
+  final MeasurementMetricEntry entry;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final onColor =
+        entry.statusColor.computeLuminance() > 0.179 ? Colors.black : Colors.white;
+    final mutedOnColor = onColor.withValues(alpha: 0.85);
+    return Container(
+      decoration: BoxDecoration(
+        color: entry.statusColor,
+        borderRadius: BorderRadius.circular(compact ? 8 : 12),
+      ),
+      padding: EdgeInsets.all(compact ? 6 : 10),
+      child: _MetricTileContent(
+        entry: entry,
+        valueColor: onColor,
+        compact: compact,
+        labelStyle: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: mutedOnColor,
+              fontSize: compact ? 10 : null,
+            ),
+        unitColor: mutedOnColor,
+        sensorColor: mutedOnColor,
+      ),
+    );
+  }
+}
+
+class _GroupedSections extends StatelessWidget {
+  const _GroupedSections({
+    required this.entries,
+    this.compact = false,
+    this.columns,
+  });
+
+  final List<MeasurementMetricEntry> entries;
+  final bool compact;
+  final int? columns;
+
+  @override
+  Widget build(BuildContext context) {
+    final grouped = {
+      for (final category in MeasurementValueCategory.values)
+        category: entries.where((e) => e.category == category).toList(),
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final category in MeasurementValueCategory.values)
+          if (grouped[category]!.isNotEmpty) ...[
+            Padding(
+              padding: const EdgeInsets.only(top: 4, bottom: 8),
+              child: Text(
+                _categoryLabel(category),
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ),
+            _MetricGrid(
+              entries: grouped[category]!,
+              tileBuilder: (entry) => _Md3StatCard(entry, compact: compact),
+              columns: columns,
+              compact: compact,
+            ),
+            const SizedBox(height: 8),
+          ],
+      ],
+    );
+  }
+
+  String _categoryLabel(MeasurementValueCategory category) => switch (category) {
+        MeasurementValueCategory.particulate => 'Feinstaub'.i18n,
+        MeasurementValueCategory.climate => 'Klima'.i18n,
+        MeasurementValueCategory.gases => 'Gase & Indizes'.i18n,
+      };
+}
+
+class _MetricTileContent extends StatelessWidget {
+  const _MetricTileContent({
+    required this.entry,
+    required this.valueColor,
+    this.labelStyle,
+    this.unitColor,
+    this.sensorColor,
+    this.compact = false,
+  });
+
+  final MeasurementMetricEntry entry;
+  final Color valueColor;
+  final TextStyle? labelStyle;
+  final Color? unitColor;
+  final Color? sensorColor;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    if (compact) {
+      final unitStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: unitColor ?? Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 9,
+            height: 1.1,
+          );
+      final sensorStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+            color: sensorColor ?? Theme.of(context).colorScheme.onSurfaceVariant,
+            fontSize: 8,
+            height: 1.1,
+          );
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            entry.label,
+            style: labelStyle,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 2),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Flexible(
+                child: Text(
+                  entry.formattedValue,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: valueColor,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                        height: 1.1,
+                      ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if (entry.unit.isNotEmpty) ...[
+                const SizedBox(width: 2),
+                Text(entry.unit, style: unitStyle),
+              ],
+            ],
+          ),
+          if (entry.sensorSymbol.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(entry.sensorHint, style: sensorStyle, maxLines: 1, overflow: TextOverflow.ellipsis),
+            ),
+        ],
+      );
+    }
+
+    final unitStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: unitColor ?? Theme.of(context).colorScheme.onSurfaceVariant,
+        );
+    final sensorStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: sensorColor ?? Theme.of(context).colorScheme.onSurfaceVariant,
+          fontSize: 10,
+        );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(entry.label, style: labelStyle, maxLines: 2, overflow: TextOverflow.ellipsis),
+        if (entry.unit.isNotEmpty) Text(entry.unit, style: unitStyle),
+        const SizedBox(height: 6),
+        Text(
+          entry.formattedValue,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: valueColor,
+                fontWeight: FontWeight.bold,
+                height: 1.1,
+              ),
+        ),
+        if (entry.sensorSymbol.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(top: 4),
+            child: Text(entry.sensorHint, style: sensorStyle),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/measurements/presentation/widgets/measurement_values_panel.i18n.dart
+++ b/lib/features/measurements/presentation/widgets/measurement_values_panel.i18n.dart
@@ -1,0 +1,49 @@
+import 'package:i18n_extension/i18n_extension.dart';
+
+extension Localization on String {
+  static final _t = Translations.byText('de') +
+      {
+        'de': 'Gemessen:',
+        'en': 'Measured:',
+      } +
+      {
+        'de': 'MD3 Stat Cards',
+        'en': 'MD3 stat cards',
+      } +
+      {
+        'de': 'App-native Tiles',
+        'en': 'App-native tiles',
+      } +
+      {
+        'de': 'Color-filled KPI',
+        'en': 'Color-filled KPI',
+      } +
+      {
+        'de': 'Gruppierte Sektionen',
+        'en': 'Grouped sections',
+      } +
+      {
+        'de': 'Feinstaub',
+        'en': 'Particulate matter',
+      } +
+      {
+        'de': 'Klima',
+        'en': 'Climate',
+      } +
+      {
+        'de': 'Gase & Indizes',
+        'en': 'Gases & indices',
+      } +
+      {
+        'de': 'Layout-Vergleich (Debug)',
+        'en': 'Layout comparison (debug)',
+      } +
+      {
+        'de': 'Alle Varianten mit denselben Mock-Messwerten zum Vergleich.',
+        'en': 'All variants using the same mock measurements for comparison.',
+      };
+
+  String get i18n => localize(this, _t);
+
+  String fill(List<Object> params) => localizeFill(this, params, _t);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,7 @@ import 'package:luftdaten.at/features/measurements/logic/trip_controller.dart';
 import 'package:luftdaten.at/features/measurements/logic/workshop_controller.dart';
 import 'package:luftdaten.at/features/devices/data/air_station_config.dart';
 import 'package:luftdaten.at/features/devices/logic/sd_ble_import_storage.dart';
+import 'package:luftdaten.at/features/measurements/logic/chart_series_preferences.dart';
 import 'package:luftdaten.at/features/measurements/logic/datahub_measurement_client.dart';
 import 'package:luftdaten.at/core/app/presentation/welcome_page.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -105,6 +106,7 @@ void main() async {
     getIt.registerSingleton<SdBleImportStorage>(SdBleImportStorage());
     getIt.registerSingleton<DatahubMeasurementClient>(DatahubMeasurementClient());
     getIt.registerSingleton<BatteryInfoAggregator>(BatteryInfoAggregator());
+    getIt.registerSingleton<ChartSeriesPreferences>(ChartSeriesPreferences()..init());
 
     await AirStationConfigWizardController.init();
     await AirStationConfigManager.loadAllConfigs();

--- a/test/unit/features/measurements/logic/chart_series_preferences_test.dart
+++ b/test/unit/features/measurements/logic/chart_series_preferences_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:luftdaten.at/features/measurements/logic/chart_series_preferences.dart';
+
+void main() {
+  late ChartSeriesPreferences prefs;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    const channel = MethodChannel('plugins.flutter.io/path_provider');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') return '/tmp';
+      if (methodCall.method == 'getTemporaryDirectory') return '/tmp';
+      return null;
+    });
+  });
+
+  setUp(() async {
+    await GetStorage.init('settings');
+    GetStorage('settings').remove('chartSeriesVisibility');
+    prefs = ChartSeriesPreferences()..init();
+  });
+
+  test('particulate PM4 defaults to hidden', () {
+    expect(
+      prefs.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm4),
+      isFalse,
+    );
+    expect(
+      prefs.isVisible(ChartSeriesChartId.particulate, ChartSeriesKeys.pm25),
+      isTrue,
+    );
+  });
+
+  test('unknown series defaults to visible', () {
+    expect(
+      prefs.isVisible(ChartSeriesChartId.temperature, 'sen5x'),
+      isTrue,
+    );
+  });
+
+  test('setVisible and isVisible round-trip', () {
+    prefs.setVisible(ChartSeriesChartId.temperature, 'sen5x', false);
+    expect(
+      prefs.isVisible(ChartSeriesChartId.temperature, 'sen5x'),
+      isFalse,
+    );
+    expect(
+      prefs.isVisible(ChartSeriesChartId.temperature, 'bme280'),
+      isTrue,
+    );
+  });
+
+  test('setAll replaces chart visibility map', () {
+    prefs.setAll(ChartSeriesChartId.particulate, {
+      ChartSeriesKeys.pm1: false,
+      ChartSeriesKeys.pm25: true,
+    });
+    expect(prefs.visibilityFor(ChartSeriesChartId.particulate), {
+      ChartSeriesKeys.pm1: false,
+      ChartSeriesKeys.pm25: true,
+    });
+  });
+
+  test('preferences persist across reload', () {
+    prefs.setVisible(ChartSeriesChartId.nox, ChartSeriesKeys.mean, false);
+
+    final reloaded = ChartSeriesPreferences()..init();
+    expect(
+      reloaded.isVisible(ChartSeriesChartId.nox, ChartSeriesKeys.mean),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
- Introduced `ChartSeriesPreferences` for managing visibility settings of chart series.
- Added new widgets for displaying measurement values, including `MeasurementValuesPanel`, `MeasurementValuesComparison`, and various layout options.
- Implemented configuration dialog for chart series visibility.
- Enhanced localization support for new components and added unit tests for `ChartSeriesPreferences`.
- Updated `ChartPage` to utilize new measurement value components and preferences management.