### PR TITLE
Refactor compass functionality and update dependencies

### DIFF
--- a/assets/compass_needle.svg
+++ b/assets/compass_needle.svg
@@ -1,6 +1,0 @@
-<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-    <!-- Red Triangle (Up) -->
-    <polygon points="50,0 65,50 35,50" fill="red" />
-    <!-- Black Triangle (Down) -->
-    <polygon points="50,100 65,50 35,50" fill="black" />
-</svg>

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -28,7 +28,6 @@ Tables below mirror **`dart pub deps --json`** (direct production and dev roots)
 | `file_picker` | `10.3.10` | pub.dev |
 | `flutter` | `0.0.0` | Flutter SDK |
 | `flutter_background_service` | `5.1.0` | pub.dev |
-| `flutter_compass` | `0.8.1` | pub.dev |
 | `flutter_displaymode` | `0.6.0` | pub.dev |
 | `flutter_file_dialog` | `3.0.2` | pub.dev |
 | `flutter_local_notifications` | `19.0.0` | pub.dev |

--- a/lib/features/map/presentation/pages/map_page.dart
+++ b/lib/features/map/presentation/pages/map_page.dart
@@ -15,15 +15,11 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
  */
-import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_animations/flutter_map_animations.dart';
 import 'package:flutter_map_location_marker/flutter_map_location_marker.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -72,7 +68,6 @@ class _MapPageState extends State<MapPage>
     duration: const Duration(milliseconds: 500),
     curve: Curves.easeInOut,
   );
-  StreamSubscription? _mapMovedSubscription;
   double _zoom = 11.2;
   final MarkerDialogController _markerDialogController = MarkerDialogController();
 
@@ -80,6 +75,7 @@ class _MapPageState extends State<MapPage>
   List<Marker> historyMarkers = [];
   late TextEditingController _textController;
   final TripController router = getIt<TripController>();
+  late final WorkshopController _workshopController;
   int primaryItem = 5; // = PM10.0
 
   bool autoCenter = true;
@@ -96,9 +92,6 @@ class _MapPageState extends State<MapPage>
         : MapCollapsibleLegend.collapsedHeight;
     return inset + 8;
   }
-
-  final CompassController _compassController = CompassController();
-  late final WorkshopController _workshopController;
 
   /// Stable TileLayer to avoid rebuild-driven connection churn (reduces tile load errors).
   /// Use tile.openstreetmap.org without subdomains (OSM recommends this; see operations#737).
@@ -178,7 +171,6 @@ class _MapPageState extends State<MapPage>
     _workshopController.removeListener(_syncMapDimension);
     router.removeListener(_syncMapDimension);
     _textController.dispose();
-    _mapMovedSubscription?.cancel();
     super.dispose();
   }
 
@@ -379,22 +371,6 @@ class _MapPageState extends State<MapPage>
           initialCenter: const LatLng(48.21919466912646, 16.383482313924404),
           initialZoom: _zoom,
           maxZoom: 18,
-          onMapReady: () {
-            _mapMovedSubscription =
-                _controller.mapController.mapEventStream.listen((MapEvent mapEvent) {
-              if (mapEvent is MapEventRotate) {
-                double rotation = mapEvent.camera.rotation;
-                _compassController.bearing.value = rotation;
-              }
-              if (mapEvent is MapEventRotateEnd) {
-                double rotation = mapEvent.camera.rotation;
-                bool showCompass = rotation != 0.0;
-                if (showCompass != _compassController.showCompass.value) {
-                  _compassController.showCompass.value = showCompass;
-                }
-              }
-            });
-          },
         ),
         children: [
           _osmTileLayer,
@@ -608,47 +584,6 @@ class _MapPageState extends State<MapPage>
                   }),
             ),
           ),
-          Align(
-            alignment: Alignment.bottomLeft,
-            child: Padding(
-              padding: const EdgeInsets.all(20),
-              child: ChangeNotifierBuilder(
-                  notifier: _compassController.showCompass,
-                  builder: (context, showCompass) {
-                    return AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 300),
-                      child: showCompass.value
-                          ? IconButton.filled(
-                              key: const Key('compass-button'),
-                              style: ButtonStyle(
-                                backgroundColor: WidgetStateProperty.all(Colors.white),
-                                elevation: WidgetStateProperty.all(2),
-                                shadowColor: WidgetStateProperty.all(Colors.black),
-                              ),
-                              tooltip: 'Nach Norden orientieren'.i18n,
-                              color: Colors.black,
-                              onPressed: () {
-                                _controller.animateTo(rotation: 0);
-                                showCompass.value = false;
-                              },
-                              icon: ChangeNotifierBuilder(
-                                  notifier: _compassController.bearing,
-                                  builder: (context, bearing) {
-                                    return Transform.rotate(
-                                      angle: bearing.value * math.pi / 180.0,
-                                      child:
-                                          SvgPicture.asset('assets/compass_needle.svg', height: 24),
-                                    );
-                                  }),
-                              padding: const EdgeInsets.all(10),
-                            )
-                          : const SizedBox(
-                              key: Key('compass-placeholder'),
-                            ),
-                    );
-                  }),
-            ),
-          ),
           ChangeNotifierBuilder(
             notifier: AppSettings.I,
             builder: (context, settings) {
@@ -824,10 +759,4 @@ class StationPM {
   final double? pm1, pm25, pm10;
 
   const StationPM({this.pm1, this.pm25, this.pm10});
-}
-
-class CompassController extends ChangeNotifier {
-  ValueNotifier<double> bearing = ValueNotifier(0);
-
-  ValueNotifier<bool> showCompass = ValueNotifier(false);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -416,7 +416,7 @@ packages:
     source: hosted
     version: "5.1.2"
   flutter_compass:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: flutter_compass
       sha256: "1b4d7e6c95a675ec8482b5c9c9ccf1ebf0ced3dbec59dce28ad609da953de850"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   flutter_local_notifications: ^19.0.0
   flutter_native_splash: ^2.3.2
   flutter_map_location_marker: ^9.1.1
-  flutter_compass: ^0.8.0
   path_provider: ^2.1.1
   share_plus: ^10.0.2
   package_info_plus: ^8.0.0
@@ -105,7 +104,6 @@ flutter:
     - assets/icon-round-2.png
     - assets/LD_logo_wordmark_blue.svg
     - assets/lottie/
-    - assets/compass_needle.svg
     - assets/audio/silent.wav
     - assets/images/
   uses-material-design: true


### PR DESCRIPTION
- Changed the dependency of `flutter_compass` from direct to transitive in `pubspec.lock`.
- Removed `flutter_compass` from `pubspec.yaml` and deleted the associated `assets/compass_needle.svg` file.
- Cleaned up unused compass-related code in `map_page.dart`, including subscriptions and UI elements.
- Updated documentation to reflect the removal of `flutter_compass`.